### PR TITLE
FYC: add error checking

### DIFF
--- a/go/bitsequence.go
+++ b/go/bitsequence.go
@@ -1,5 +1,7 @@
 package bitsequence
 
+import "fmt"
+
 // BitSequence turns an arbitrary sequence of bits from a byte array into an integer.
 //
 // - `bytes` is a simple byte array of arbitrary length
@@ -9,15 +11,18 @@ package bitsequence
 // - `length` is the number of bits to extract from the `bytes` array. This value can only be a maximum of `32`, higher values will be adjusted down.
 //
 // Returns an unsigned integer version of the bit sequence. The most significant bit is not interpreted for a two's compliment representation.
-func BitSequence(bytes []byte, bitStart uint32, bitLength uint32) uint32 {
+func BitSequence(bytes []byte, bitStart uint32, bitLength uint32) (uint32, error) {
 	if bitLength > 32 {
-		// does this constraint deserve an Error?
-		bitLength = 32
+		return 0, fmt.Errorf("maximum bits that can be read is 32")
 	}
 	startOffset := bitStart % 8
 	byteCount := (7 + startOffset + bitLength) / 8
 	byteStart := bitStart / 8
 	endOffset := byteCount*8 - bitLength - startOffset
+
+	if int(byteStart+byteCount) > len(bytes) {
+		return 0, fmt.Errorf("cannot read past end of bytes array")
+	}
 
 	var result uint32
 
@@ -48,5 +53,5 @@ func BitSequence(bytes []byte, bitStart uint32, bitLength uint32) uint32 {
 		result = result | uint32(local)
 	}
 
-	return result
+	return result, nil
 }

--- a/go/bitsequence_test.go
+++ b/go/bitsequence_test.go
@@ -23,7 +23,14 @@ func TestFixtures(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual := BitSequence(testCase.bytes, testCase.start, testCase.length)
+		actual, err := BitSequence(testCase.bytes, testCase.start, testCase.length)
+		if err != nil {
+			t.Errorf("Bytes [%s] start=%d length=%d returned an error reading",
+				hex.EncodeToString(testCase.bytes),
+				testCase.start,
+				testCase.length,
+			)
+		}
 		if actual != testCase.expected {
 			t.Errorf("Bytes [%s] start=%d length=%d expected %d but got %d",
 				hex.EncodeToString(testCase.bytes),
@@ -39,6 +46,21 @@ func TestFixtures(t *testing.T) {
 				testCase.expected,
 				actual)
 		} */
+	}
+}
+
+func TestReadPastEndErrors(t *testing.T) {
+	bytes, err := hex.DecodeString("ff")
+	if err != nil {
+		panic(err)
+	}
+	_, err = BitSequence(bytes, 16, 1)
+	if err == nil {
+		t.Errorf("Should not have allowed reading past end of byte array but did")
+	}
+	_, err = BitSequence(bytes, 14, 6)
+	if err == nil {
+		t.Errorf("Should not have allowed reading past end of byte array but did")
 	}
 }
 


### PR DESCRIPTION
# Goals

- match go pattern of returning errors frequently
- make function behave as in spec - don't allow values greater than 32
- prevent reading past end of byte array, which would cause a panic

# Implementation

- add an error to return value for BitSequence, check for illegal bitLength and reading past end of
bytes (would panic otherwise)
- add test to verify error checking when reading past end of byte array
